### PR TITLE
Typo Fix in Risc0 Tutorial Docs

### DIFF
--- a/docs/tutorials/08-run-a-zkrollup/05-risc0_installation.md
+++ b/docs/tutorials/08-run-a-zkrollup/05-risc0_installation.md
@@ -66,7 +66,7 @@ In order to build the application, go through the following steps:
     println!("Input argument is: {}", input);
     ```
 
-    and the the lines:
+    and the lines:
 
     ```rust
     // TODO: Implement code for retrieving receipt journal here.


### PR DESCRIPTION
### Description of the Changes
Fixed a typo by removing a redundant "the" in the [zkRollup Integrations - Risc0](https://docs.zkverify.io/tutorials/run-a-zkrollup/risc0_installation/) documentation.

I came across this when I was referring to the docs while working on my project for the **_ZK Online Hackathon for Web3 Builders_**.

![swappy-20250207-002653](https://github.com/user-attachments/assets/77c9f309-b104-49e7-98ff-49bf324e7324)

