### PR TITLE
Remove trailing slash from URLs

### DIFF
--- a/docusaurus.config.ts
+++ b/docusaurus.config.ts
@@ -15,6 +15,7 @@ const config: Config = {
   // Set the /<baseUrl>/ pathname under which your site is served
   // For GitHub pages deployment, it is often '/<projectName>/'
   baseUrl: '/',
+  trailingSlash: false,
 
   // Even if you don't use internationalization, you can use this field to set
   // useful metadata like html lang. For example, if your site is Chinese, you


### PR DESCRIPTION
With trailing slashes, links on the page were directing elsewhere

For example from `/tutorials/tutorials/` page, `/connect-a-wallet` linked to `/tutorials/tutorials/connect-a-wallet` instead of `/tutorials/connect-a-wallet`