### PR TITLE
Correct typo: 'high-performant' to 'high-performance' and fix spacing…

### DIFF
--- a/docs/overview/01-introduction.md
+++ b/docs/overview/01-introduction.md
@@ -3,7 +3,7 @@ slug: /
 ---
 # What is zkVerify
 
-zkVerify is a high-performant, public, and decentralized blockchain dedicated to zero-knowledge proof verification. It provides a modular and composable approach for ZK apps to verify proofs. 
+zkVerify is a high-performance, public, and decentralized blockchain dedicated to zero-knowledge proof verification. It provides a modular and composable approach for ZK apps to verify proofs. 
 
 ## Goals of zkVerify
 
@@ -18,7 +18,7 @@ Both steps are essential to confirm that the computation is correct. While many 
 
 zkVerify solves this by accepting proofs, verifying them, and recording both the proof and its verification on the blockchain for future reference.
 
-## What is zkVerify trying to solve ?
+## What is zkVerify trying to solve?
 
 ### Proof verification costs
 


### PR DESCRIPTION
… in question header

This PR corrects the term "high-performant" to "high-performance" and removes the extra space before the question mark in the header "What is zkVerify trying to solve?" in docs/overview/01-introduction.md.

This is just a minor PR and doesn't affect the code.