### PR TITLE
Fix broken links after file renumbering

### DIFF
--- a/docs/architecture/04-proof-aggregation/05-domain-management.md
+++ b/docs/architecture/04-proof-aggregation/05-domain-management.md
@@ -38,7 +38,7 @@ For each of these domains, we are providing the following guarantees:
 
 [Please find the list below](#listdomains)
 
-For the addresses of the contracts we have deployed on all the destination chains, please refer to the appropriate [section](../../overview/06-contract-addresses.md) of the docs.
+For the addresses of the contracts we have deployed on all the destination chains, please refer to the appropriate [section](../../overview/05-contract-addresses.md) of the docs.
 
 | Domain ID | Chain             | Mechanism   |
 | --------- | ----------------- | ----------- |

--- a/docs/overview/02-getting-started/05-relayer.md
+++ b/docs/overview/02-getting-started/05-relayer.md
@@ -334,7 +334,7 @@ console.log(requestResponse.data)
 </Tabs>
 </TabItem>
 <TabItem value="with-aggregation" label="With Aggregation">
-We need to define the chainId where we want to verify our aggregated proof. You can find the chain ID for all the supported networks [here](../06-contract-addresses.md)
+We need to define the chainId where we want to verify our aggregated proof. You can find the chain ID for all the supported networks [here](../05-contract-addresses.md)
 <Tabs groupId="submit-proof">
 <TabItem value="circom" label="Circom">
 ```js


### PR DESCRIPTION
- Update references from 06-contract-addresses.md to 05-contract-addresses.md
- Fix broken links in domain management and relayer documentation