### PR TITLE
Add new supported attestation chains

### DIFF
--- a/docs/architecture/04-proof-aggregation/05-domain-management.md
+++ b/docs/architecture/04-proof-aggregation/05-domain-management.md
@@ -45,10 +45,10 @@ For the addresses of the contracts we have deployed on all the destination chain
 | Domain ID | Chain             | Mechanism   |
 | --------- | ----------------- | ----------- |
 | 8         | Apechain          | Bot         |
+| 10        | Arbitrum One      | Bot         |
 | 2         | Base              | Bot         |
 | 3         | Horizen           | Bot         |
 | 9         | OP Mainnet        | Bot         |
-| 10        | Arbitrum One      | Bot         |
 </TabItem>
 <TabItem value="testnet" label="Testnet">
 | Domain ID | Chain             | Mechanism   |

--- a/docs/architecture/04-proof-aggregation/05-domain-management.md
+++ b/docs/architecture/04-proof-aggregation/05-domain-management.md
@@ -44,18 +44,22 @@ For the addresses of the contracts we have deployed on all the destination chain
 <TabItem value="mainnet" label="Mainnet">
 | Domain ID | Chain             | Mechanism   |
 | --------- | ----------------- | ----------- |
+| 8         | Apechain          | Bot         |
 | 2         | Base              | Bot         |
 | 3         | Horizen           | Bot         |
+| 9         | OP Mainnet        | Bot         |
+| 10        | Arbitrum One      | Bot         |
 </TabItem>
 <TabItem value="testnet" label="Testnet">
 | Domain ID | Chain             | Mechanism   |
 | --------- | ----------------- | ----------- |
-| 175       | Horizen Testnet   | Bot         |
-| 0         | Ethereum Sepolia  | Bot         |
-| 2         | Base Sepolia      | Bot         |
-| 3         | Optimism Sepolia  | Bot         |
+| 236       | Apechain Curtis   | Bot         |
 | 4         | Arbitrum Sepolia  | Bot         |
+| 2         | Base Sepolia      | Bot         |
 | 56        | EDU Chain Testnet | Bot         |
+| 0         | Ethereum Sepolia  | Bot         |
+| 175       | Horizen Testnet   | Bot         |
+| 3         | Optimism Sepolia  | Bot         |
 </TabItem>
 </Tabs>
 

--- a/docs/architecture/08-contract-addresses.md
+++ b/docs/architecture/08-contract-addresses.md
@@ -7,19 +7,23 @@ import TabItem from '@theme/TabItem';
 
 <Tabs groupId="networks">
 <TabItem value="mainnet" label="Mainnet">
-| Network                                                     | Contract Address                                                                                                                                                                                                             | Chain ID                                                     
-| ----------------------------------------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |  ----------------------------------------------------------- 
-| Base | [`Contract`](https://basescan.org/address/0x5596aE76a636483361C9e777C03091BAEDcEa1C6) [`Proxy`](https://basescan.org/address/0xCb47A3C3B9Eb2E549a3F2EA4729De28CafbB2b69)                         | 8453 |
-| Horizen | [`Proxy`](https://horizen.calderaexplorer.xyz/address/0xCb47A3C3B9Eb2E549a3F2EA4729De28CafbB2b69)                         | 26514 |
+| Network | Contract Address | Chain ID |
+| --- | --- | --- |
+| Apechain | [`Proxy`](https://apescan.io/address/0x1a6fe16501ab68adb8d3bb24c299e79cbf190d39) | 33139 | 
+| Arbitrum One | [`Proxy`](https://arbiscan.io/address/0xCb47A3C3B9Eb2E549a3F2EA4729De28CafbB2b69) | 42161 |
+| Base | [`Proxy`](https://basescan.org/address/0xCb47A3C3B9Eb2E549a3F2EA4729De28CafbB2b69) | 8453 |
+| Horizen | [`Proxy`](https://horizen.calderaexplorer.xyz/address/0xCb47A3C3B9Eb2E549a3F2EA4729De28CafbB2b69) | 26514 |
+| OP Mainnet | [`Proxy`](https://optimistic.etherscan.io/address/0xcb47a3c3b9eb2e549a3f2ea4729de28cafbb2b69) | 10 |
 </TabItem>
 <TabItem value="testnet" label="Testnet">
-| Network                                                     | Contract Address                                                                                                                                                                                                             | Chain ID                                                     
-| ----------------------------------------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |  ----------------------------------------------------------- 
-| Sepolia (Ethereum testnet) | [`Contract`](https://sepolia.etherscan.io/address/0x5a3c35CCC5c05fDeFe5Ecafc15F4B1aC8eF71481) [`Proxy`](https://sepolia.etherscan.io/address/0xEA0A0f1EfB1088F4ff0Def03741Cb2C64F89361E)                         | 11155111 |
-| Arbitrum (Sepolia testnet) | [`Contract`](https://sepolia.arbiscan.io/address/0x8fDFE115948b54e77134Ff3841a626FAd4E6A661) [`Proxy`](https://sepolia.arbiscan.io/address/0xd007494945580eEb25522c8e0b2fa798B3F0FDE2)                           | 421614 |
-| Base (Sepolia testnet)      | [`Contract`](https://sepolia.basescan.org/address/0x312468EbF274F1f584d93d0CCA8458cC91460FC0) [`Proxy`](https://sepolia.basescan.org/address/0x0807C544D38aE7729f8798388d89Be6502A1e8A8)                         | 84532 |
-| Optimism (Sepolia testnet) | [`Contract`](https://sepolia-optimism.etherscan.io/address/0xFbA954966Fa27adec13Ba42F96E9F8ec8308a860) [`Proxy`](https://sepolia-optimism.etherscan.io/address/0xBBa17b0Eb3DdF0631c0Cce00E4245E4A2EE49982)       | 11155420 |
-| EDU Chain (Testnet)        | [`Contract`](https://edu-chain-testnet.blockscout.com/address/0x8fDFE115948b54e77134Ff3841a626FAd4E6A661) [`Proxy`](https://edu-chain-testnet.blockscout.com/address/0xd007494945580eEb25522c8e0b2fa798B3F0FDE2) | 656476 |
-| Horizen (Testnet)    | [`Contract`](https://horizen-testnet.explorer.caldera.xyz/address/0x03225ff1ff4F1BAc6e81BB6317006A509422D51C) [`Proxy`](https://horizen-testnet.explorer.caldera.xyz/address/0x3098A6974649478f0133046e44105AA84e868C21) | 2651420 |
+| Network | Contract Address | Chain ID |
+| --- | --- | --- |
+| Apechain (Curtis testnet) | [`Proxy`](https://explorer.curtis.apechain.com/address/0xCd9362B2310a4516369057437a6B4A57Fd3cD0E9) | 33111 |
+| Arbitrum (Sepolia testnet) | [`Proxy`](https://sepolia.arbiscan.io/address/0xd007494945580eEb25522c8e0b2fa798B3F0FDE2) | 421614 |
+| Base (Sepolia testnet) | [`Proxy`](https://sepolia.basescan.org/address/0x0807C544D38aE7729f8798388d89Be6502A1e8A8) | 84532 |
+| EDU Chain (Testnet) | [`Proxy`](https://edu-chain-testnet.blockscout.com/address/0xd007494945580eEb25522c8e0b2fa798B3F0FDE2) | 656476 |
+| Horizen (Testnet) | [`Proxy`](https://horizen-testnet.explorer.caldera.xyz/address/0x3098A6974649478f0133046e44105AA84e868C21) | 2651420 |
+| Optimism (Sepolia testnet) | [`Proxy`](https://sepolia-optimism.etherscan.io/address/0xBBa17b0Eb3DdF0631c0Cce00E4245E4A2EE49982) | 11155420 |
+| Sepolia (Ethereum testnet) | [`Proxy`](https://sepolia.etherscan.io/address/0xEA0A0f1EfB1088F4ff0Def03741Cb2C64F89361E) | 11155111 |
 </TabItem>
 </Tabs>


### PR DESCRIPTION
- Added new chains:
    * mainnet: Apechain, OP, Arbitrum One
    * testnet: Apechain Curtis
    
- Reordered chain in alphabetical order

- Removed information about implementation addresses:
    * not useful for users (and developers too)
    * easily retrievable from block explorers
    * gets outdated when upgrading contracts